### PR TITLE
Fix description of API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Deploying with serverless is pretty easy:
 sls deploy --stage dev
 ```
 
-Right now there is only stage `dev`.  The output from this command should give you the host so that you can send your requests using `curl <HOST>/ping`.
+Right now there is only stage `dev`.  The output from this command should give you the host so that you can send your requests using `curl <HOST>`.
 
 To tear down deployment:
 ```console
@@ -17,5 +17,5 @@ sls remove --stage dev
 ```
 
 ## API
-The API is in POC phase.  Just a simple `/ping` endpoint.  This is to make sure I can get a functioning go API.
+The API is in POC phase.  All requests to the host are routed to the single handler.
 


### PR DESCRIPTION
Initially I wanted to have a single endpoint called `ping` that would return `pong` as a response.  I ended up using a wildcard endpoint.  Now the docs reflect this.

closes #5