### PR TITLE
Deployment Bucket and Buildspec for dev deploys

### DIFF
--- a/.serverless/cloudformation-template-update-stack.json
+++ b/.serverless/cloudformation-template-update-stack.json
@@ -90,8 +90,8 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
-          "S3Key": "serverless/calmap/dev/1747436494663-2025-05-16T23:01:34.663Z/ping.zip"
+          "S3Bucket": "calmap-deploy-dev",
+          "S3Key": "serverless/calmap/dev/1747439577727-2025-05-16T23:52:57.727Z/ping.zip"
         },
         "Handler": ".bin/ping",
         "Runtime": "provided.al2",
@@ -112,14 +112,14 @@
         "PingLogGroup"
       ]
     },
-    "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E": {
+    "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PingLambdaFunction"
         },
-        "CodeSha256": "fNBqJFxfoAeboljXww5uhbkazkzvEgZ3ahnMCzFbmfY="
+        "CodeSha256": "G2ggOuxweAPiPiI2CL0HtuGz0XdVRXsk7ZsJYbv6S1o="
       }
     },
     "HttpApi": {
@@ -220,7 +220,7 @@
   },
   "Outputs": {
     "ServerlessDeploymentBucketName": {
-      "Value": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
+      "Value": "calmap-deploy-dev",
       "Export": {
         "Name": "sls-calmap-dev-ServerlessDeploymentBucketName"
       }
@@ -228,7 +228,7 @@
     "PingLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E"
+        "Ref": "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU"
       },
       "Export": {
         "Name": "sls-calmap-dev-PingLambdaFunctionQualifiedArn"

--- a/.serverless/meta.json
+++ b/.serverless/meta.json
@@ -12,9 +12,13 @@
         "architecture": "arm64",
         "deploymentMethod": "direct",
         "runtime": "provided.al2",
-        "region": "us-west-2",
+        "region": "us-west-1",
+        "deploymentBucket": "calmap-deploy-dev",
         "stage": "dev",
         "versionFunctions": true,
+        "deploymentBucketObject": {
+          "name": "calmap-deploy-dev"
+        },
         "compiledCloudFormationTemplate": {
           "AWSTemplateFormatVersion": "2010-09-09",
           "Description": "The AWS CloudFormation template for this Serverless application",
@@ -107,8 +111,8 @@
               "Type": "AWS::Lambda::Function",
               "Properties": {
                 "Code": {
-                  "S3Bucket": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
-                  "S3Key": "serverless/calmap/dev/1747436494663-2025-05-16T23:01:34.663Z/ping.zip"
+                  "S3Bucket": "calmap-deploy-dev",
+                  "S3Key": "serverless/calmap/dev/1747439577727-2025-05-16T23:52:57.727Z/ping.zip"
                 },
                 "Handler": ".bin/ping",
                 "Runtime": "provided.al2",
@@ -129,14 +133,14 @@
                 "PingLogGroup"
               ]
             },
-            "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E": {
+            "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU": {
               "Type": "AWS::Lambda::Version",
               "DeletionPolicy": "Retain",
               "Properties": {
                 "FunctionName": {
                   "Ref": "PingLambdaFunction"
                 },
-                "CodeSha256": "fNBqJFxfoAeboljXww5uhbkazkzvEgZ3ahnMCzFbmfY="
+                "CodeSha256": "G2ggOuxweAPiPiI2CL0HtuGz0XdVRXsk7ZsJYbv6S1o="
               }
             },
             "HttpApi": {
@@ -237,7 +241,7 @@
           },
           "Outputs": {
             "ServerlessDeploymentBucketName": {
-              "Value": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
+              "Value": "calmap-deploy-dev",
               "Export": {
                 "Name": "sls-calmap-dev-ServerlessDeploymentBucketName"
               }
@@ -245,7 +249,7 @@
             "PingLambdaFunctionQualifiedArn": {
               "Description": "Current Lambda function version",
               "Value": {
-                "Ref": "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E"
+                "Ref": "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU"
               },
               "Export": {
                 "Name": "sls-calmap-dev-PingLambdaFunctionQualifiedArn"
@@ -310,7 +314,7 @@
           "timeout": 6,
           "runtime": "provided.al2",
           "vpc": {},
-          "versionLogicalId": "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E"
+          "versionLogicalId": "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU"
         }
       },
       "custom": {
@@ -327,9 +331,13 @@
       "architecture": "arm64",
       "deploymentMethod": "direct",
       "runtime": "provided.al2",
-      "region": "us-west-2",
+      "region": "us-west-1",
+      "deploymentBucket": "calmap-deploy-dev",
       "stage": "dev",
       "versionFunctions": true,
+      "deploymentBucketObject": {
+        "name": "calmap-deploy-dev"
+      },
       "compiledCloudFormationTemplate": {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Description": "The AWS CloudFormation template for this Serverless application",
@@ -422,8 +430,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
               "Code": {
-                "S3Bucket": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
-                "S3Key": "serverless/calmap/dev/1747436494663-2025-05-16T23:01:34.663Z/ping.zip"
+                "S3Bucket": "calmap-deploy-dev",
+                "S3Key": "serverless/calmap/dev/1747439577727-2025-05-16T23:52:57.727Z/ping.zip"
               },
               "Handler": ".bin/ping",
               "Runtime": "provided.al2",
@@ -444,14 +452,14 @@
               "PingLogGroup"
             ]
           },
-          "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E": {
+          "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "PingLambdaFunction"
               },
-              "CodeSha256": "fNBqJFxfoAeboljXww5uhbkazkzvEgZ3ahnMCzFbmfY="
+              "CodeSha256": "G2ggOuxweAPiPiI2CL0HtuGz0XdVRXsk7ZsJYbv6S1o="
             }
           },
           "HttpApi": {
@@ -552,7 +560,7 @@
         },
         "Outputs": {
           "ServerlessDeploymentBucketName": {
-            "Value": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
+            "Value": "calmap-deploy-dev",
             "Export": {
               "Name": "sls-calmap-dev-ServerlessDeploymentBucketName"
             }
@@ -560,7 +568,7 @@
           "PingLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E"
+              "Ref": "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU"
             },
             "Export": {
               "Name": "sls-calmap-dev-PingLambdaFunctionQualifiedArn"
@@ -623,7 +631,7 @@
       },
       "instanceParameters": null
     },
-    "serviceRawFile": "org: joebot\napp: calmap\nservice: calmap\n\nprovider:\n  name: aws\n  architecture: arm64\n  deploymentMethod: direct\n  runtime: provided.al2\n  region: us-west-2\n\nplugins:\n  - serverless-go-plugin\n\nfunctions:\n  ping:\n    handler: ./functions/ping\n    events:\n      - httpApi: '*'\n\ncustom:\n  go:\n    supportedRuntimes: [\"provided.al2\"]\n    buildProvidedRuntimeAsBootstrap: true",
+    "serviceRawFile": "org: joebot\napp: calmap\nservice: calmap\n\nprovider:\n  name: aws\n  architecture: arm64\n  deploymentMethod: direct\n  runtime: provided.al2\n  region: us-west-1\n\n  deploymentBucket:\n    name: calmap-deploy-${sls:stage}\n\nplugins:\n  - serverless-go-plugin\n\nfunctions:\n  ping:\n    handler: ./functions/ping\n    events:\n      - httpApi: '*'\n\ncustom:\n  go:\n    supportedRuntimes: [\"provided.al2\"]\n    buildProvidedRuntimeAsBootstrap: true",
     "command": [
       "deploy"
     ],
@@ -636,31 +644,31 @@
     "userName": "joebot",
     "serviceProviderAwsAccountId": "952137072399",
     "serviceProviderAwsCfStackName": "calmap-dev",
-    "serviceProviderAwsCfStackId": "arn:aws:cloudformation:us-west-2:952137072399:stack/calmap-dev/84867690-32a6-11f0-8c79-021726b2ea31",
-    "serviceProviderAwsCfStackCreated": "2025-05-16T22:38:41.891Z",
-    "serviceProviderAwsCfStackUpdated": "2025-05-16T22:50:47.753Z",
-    "serviceProviderAwsCfStackStatus": "UPDATE_COMPLETE",
+    "serviceProviderAwsCfStackId": "arn:aws:cloudformation:us-west-1:952137072399:stack/calmap-dev/e57f6650-32b0-11f0-8005-06cdd4a120bd",
+    "serviceProviderAwsCfStackCreated": "2025-05-16T23:52:59.782Z",
+    "serviceProviderAwsCfStackUpdated": null,
+    "serviceProviderAwsCfStackStatus": "CREATE_COMPLETE",
     "serviceProviderAwsCfStackOutputs": [
       {
         "OutputKey": "PingLambdaFunctionQualifiedArn",
-        "OutputValue": "arn:aws:lambda:us-west-2:952137072399:function:calmap-dev-ping:3",
+        "OutputValue": "arn:aws:lambda:us-west-1:952137072399:function:calmap-dev-ping:1",
         "Description": "Current Lambda function version",
         "ExportName": "sls-calmap-dev-PingLambdaFunctionQualifiedArn"
       },
       {
         "OutputKey": "HttpApiId",
-        "OutputValue": "famoexibz2",
+        "OutputValue": "49fuv420uf",
         "Description": "Id of the HTTP API",
         "ExportName": "sls-calmap-dev-HttpApiId"
       },
       {
         "OutputKey": "ServerlessDeploymentBucketName",
-        "OutputValue": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
+        "OutputValue": "calmap-deploy-dev",
         "ExportName": "sls-calmap-dev-ServerlessDeploymentBucketName"
       },
       {
         "OutputKey": "HttpApiUrl",
-        "OutputValue": "https://famoexibz2.execute-api.us-west-2.amazonaws.com",
+        "OutputValue": "https://49fuv420uf.execute-api.us-west-1.amazonaws.com",
         "Description": "URL of the HTTP API",
         "ExportName": "sls-calmap-dev-HttpApiUrl"
       }
@@ -757,8 +765,8 @@
           "Type": "AWS::Lambda::Function",
           "Properties": {
             "Code": {
-              "S3Bucket": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
-              "S3Key": "serverless/calmap/dev/1747436494663-2025-05-16T23:01:34.663Z/ping.zip"
+              "S3Bucket": "calmap-deploy-dev",
+              "S3Key": "serverless/calmap/dev/1747439577727-2025-05-16T23:52:57.727Z/ping.zip"
             },
             "Handler": ".bin/ping",
             "Runtime": "provided.al2",
@@ -779,14 +787,14 @@
             "PingLogGroup"
           ]
         },
-        "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E": {
+        "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU": {
           "Type": "AWS::Lambda::Version",
           "DeletionPolicy": "Retain",
           "Properties": {
             "FunctionName": {
               "Ref": "PingLambdaFunction"
             },
-            "CodeSha256": "fNBqJFxfoAeboljXww5uhbkazkzvEgZ3ahnMCzFbmfY="
+            "CodeSha256": "G2ggOuxweAPiPiI2CL0HtuGz0XdVRXsk7ZsJYbv6S1o="
           }
         },
         "HttpApi": {
@@ -887,7 +895,7 @@
       },
       "Outputs": {
         "ServerlessDeploymentBucketName": {
-          "Value": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
+          "Value": "calmap-deploy-dev",
           "Export": {
             "Name": "sls-calmap-dev-ServerlessDeploymentBucketName"
           }
@@ -895,7 +903,7 @@
         "PingLambdaFunctionQualifiedArn": {
           "Description": "Current Lambda function version",
           "Value": {
-            "Ref": "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E"
+            "Ref": "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU"
           },
           "Export": {
             "Name": "sls-calmap-dev-PingLambdaFunctionQualifiedArn"

--- a/.serverless/serverless-state.json
+++ b/.serverless/serverless-state.json
@@ -9,9 +9,13 @@
       "architecture": "arm64",
       "deploymentMethod": "direct",
       "runtime": "provided.al2",
-      "region": "us-west-2",
+      "region": "us-west-1",
+      "deploymentBucket": "calmap-deploy-dev",
       "stage": "dev",
       "versionFunctions": true,
+      "deploymentBucketObject": {
+        "name": "calmap-deploy-dev"
+      },
       "compiledCloudFormationTemplate": {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Description": "The AWS CloudFormation template for this Serverless application",
@@ -104,8 +108,8 @@
             "Type": "AWS::Lambda::Function",
             "Properties": {
               "Code": {
-                "S3Bucket": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
-                "S3Key": "serverless/calmap/dev/1747436494663-2025-05-16T23:01:34.663Z/ping.zip"
+                "S3Bucket": "calmap-deploy-dev",
+                "S3Key": "serverless/calmap/dev/1747439577727-2025-05-16T23:52:57.727Z/ping.zip"
               },
               "Handler": ".bin/ping",
               "Runtime": "provided.al2",
@@ -126,14 +130,14 @@
               "PingLogGroup"
             ]
           },
-          "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E": {
+          "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU": {
             "Type": "AWS::Lambda::Version",
             "DeletionPolicy": "Retain",
             "Properties": {
               "FunctionName": {
                 "Ref": "PingLambdaFunction"
               },
-              "CodeSha256": "fNBqJFxfoAeboljXww5uhbkazkzvEgZ3ahnMCzFbmfY="
+              "CodeSha256": "G2ggOuxweAPiPiI2CL0HtuGz0XdVRXsk7ZsJYbv6S1o="
             }
           },
           "HttpApi": {
@@ -231,7 +235,7 @@
         },
         "Outputs": {
           "ServerlessDeploymentBucketName": {
-            "Value": "serverless-framework-deployments-us-west-2-d60ee5a3-77e3",
+            "Value": "calmap-deploy-dev",
             "Export": {
               "Name": "sls-calmap-dev-ServerlessDeploymentBucketName"
             }
@@ -239,7 +243,7 @@
           "PingLambdaFunctionQualifiedArn": {
             "Description": "Current Lambda function version",
             "Value": {
-              "Ref": "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E"
+              "Ref": "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU"
             },
             "Export": {
               "Name": "sls-calmap-dev-PingLambdaFunctionQualifiedArn"
@@ -313,7 +317,7 @@
         "timeout": 6,
         "runtime": "provided.al2",
         "vpc": {},
-        "versionLogicalId": "PingLambdaVersion6LPBYiBNmkuEXcheGkFSZngb4ByEO5UC4pUnRSq2E"
+        "versionLogicalId": "PingLambdaVersion982lzG1wixzYpdi9ALrM4J4faD9JbPjVaE8sXKcKU"
       }
     },
     "configValidationMode": "warn",
@@ -342,7 +346,7 @@
     "layers": {}
   },
   "package": {
-    "artifactDirectoryName": "serverless/calmap/dev/1747436494663-2025-05-16T23:01:34.663Z",
+    "artifactDirectoryName": "serverless/calmap/dev/1747439577727-2025-05-16T23:52:57.727Z",
     "artifact": ""
   }
 }

--- a/deploy/buildspec-dev.yml
+++ b/deploy/buildspec-dev.yml
@@ -1,0 +1,10 @@
+phases:
+  install:
+    commands:
+      - npm install
+  build:
+    commands:
+      - sls deploy --stage dev --verbose
+artifacts:
+  files:
+    - '**/*'

--- a/functions/ping/main.go
+++ b/functions/ping/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func handler(ctx context.Context) (string, error) {
-	return "pong!", nil
+	return "auto-deployed pong!", nil
 }
 
 func main() {

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,10 @@ provider:
   architecture: arm64
   deploymentMethod: direct
   runtime: provided.al2
-  region: us-west-2
+  region: us-west-1
+
+  deploymentBucket:
+    name: calmap-deploy-${sls:stage}
 
 plugins:
   - serverless-go-plugin


### PR DESCRIPTION
This PR adds a custom deployement bucket for artifacts of the build/deploy process.  We also define a custom buildspec-dev file that allows us to use in a AWS Code Pipeline to deploy changes to dev on any push to main.

closes #3